### PR TITLE
Improve Simplified Chinese localization

### DIFF
--- a/Code/Desktop Frames/Localization/Strings.zh-Hans.resx
+++ b/Code/Desktop Frames/Localization/Strings.zh-Hans.resx
@@ -1,6 +1,64 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- Seed translation produced with AI assistance and not yet reviewed by a native speaker. Any key that is ever removed falls back to English at runtime. -->
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -63,12 +121,12 @@
     <value> 和 </value>
   </data>
   <data name="AboutBody" xml:space="preserve">
-    <value>Desktop Frames + 在桌面上创建虚拟框，让图标分组归位，整洁又顺手。</value>
+    <value>Desktop Frames + 可在桌面上创建虚拟面板，方便你分组整理图标，让桌面更整洁、更顺手。</value>
   </data>
   <data name="AboutCreditsBody" xml:space="preserve">
-    <value>Desktop Frames + 是一款面向 Windows 的开源工具，最初由 HakanKokcu 以 BirdyFences 之名开发。
+    <value>Desktop Frames + 是一款适用于 Windows 的开源工具，最初由 HakanKokcu 以 BirdyFences 之名开发。
 
-目前由 Nikos Georgousis 维护，他对其加以扩充，使之更稳定、更好用。</value>
+目前由 Nikos Georgousis 维护，并持续改进其功能、稳定性与使用体验。</value>
   </data>
   <data name="AboutDonateBig" xml:space="preserve">
     <value>捐赠 999,00 €</value>
@@ -77,7 +135,7 @@
     <value>请勿投喂龙</value>
   </data>
   <data name="AboutGreatToHaveYou" xml:space="preserve">
-    <value>很高兴见到你</value>
+    <value>很高兴你能来</value>
   </data>
   <data name="AboutLicense" xml:space="preserve">
     <value>⚖ MIT 许可证</value>
@@ -95,7 +153,7 @@
     <value>免费音效来自 </value>
   </data>
   <data name="AboutSupportDevelopment" xml:space="preserve">
-    <value>支持开发</value>
+    <value>支持项目开发</value>
   </data>
   <data name="AboutTagline" xml:space="preserve">
     <value>像变魔术一样整理你的桌面。</value>
@@ -131,7 +189,7 @@
     <value>管理自动化规则</value>
   </data>
   <data name="AutomationPersistedMode" xml:space="preserve">
-    <value>持久模式（关闭后仍停留在该配置）</value>
+    <value>保持模式（窗口关闭后仍停留在该工作区）</value>
   </data>
   <data name="AutomationPickWindow" xml:space="preserve">
     <value>🎯 选择窗口</value>
@@ -155,10 +213,10 @@
     <value>启用此规则</value>
   </data>
   <data name="AutoOrgFilenameContains" xml:space="preserve">
-    <value>且名称包含（可选，留空表示任意）：</value>
+    <value>且文件名包含（可选，留空表示不限）：</value>
   </data>
   <data name="AutoOrgGeneratePortal" xml:space="preserve">
-    <value>为此文件夹创建门户框</value>
+    <value>为此文件夹创建文件夹面板</value>
   </data>
   <data name="AutoOrgIfExists" xml:space="preserve">
     <value>若文件已存在：</value>
@@ -182,13 +240,13 @@
     <value>智能桌面规则</value>
   </data>
   <data name="BackupSelectExportFile" xml:space="preserve">
-    <value>选择框的导出文件</value>
+    <value>选择面板导出文件</value>
   </data>
   <data name="BtnApply" xml:space="preserve">
     <value>应用</value>
   </data>
   <data name="BtnApplyToAll" xml:space="preserve">
-    <value>应用到全部</value>
+    <value>全部应用</value>
   </data>
   <data name="BtnBackup" xml:space="preserve">
     <value>备份</value>
@@ -214,14 +272,11 @@
   <data name="BtnDonate" xml:space="preserve">
     <value>♥ 通过 PayPal 捐赠</value>
   </data>
-  <data name="BtnImportLanguagePack" xml:space="preserve">
-    <value>导入语言包…</value>
-  </data>
   <data name="BtnManageAutomation" xml:space="preserve">
     <value>管理自动化</value>
   </data>
   <data name="BtnManageProfiles" xml:space="preserve">
-    <value>管理配置</value>
+    <value>管理工作区</value>
   </data>
   <data name="BtnMoveDown" xml:space="preserve">
     <value>▼ 下移</value>
@@ -231,9 +286,6 @@
   </data>
   <data name="BtnOpenBackupsFolder" xml:space="preserve">
     <value>打开备份文件夹</value>
-  </data>
-  <data name="BtnOpenLanguagesFolder" xml:space="preserve">
-    <value>打开语言文件夹</value>
   </data>
   <data name="BtnOpenLog" xml:space="preserve">
     <value>打开日志</value>
@@ -248,16 +300,16 @@
     <value>重置样式</value>
   </data>
   <data name="BtnRestore" xml:space="preserve">
-    <value>恢复…</value>
+    <value>还原…</value>
   </data>
   <data name="BtnSave" xml:space="preserve">
     <value>保存</value>
   </data>
   <data name="BtnSaveToAll" xml:space="preserve">
-    <value>保存到全部</value>
+    <value>全部保存</value>
   </data>
   <data name="BtnScreenBoundFrames" xml:space="preserve">
-    <value>将框移回屏幕内</value>
+    <value>将面板移回屏幕内</value>
   </data>
   <data name="BtnSmartDesktopRules" xml:space="preserve">
     <value>智能桌面规则…</value>
@@ -284,13 +336,13 @@
     <value>已全部清除</value>
   </data>
   <data name="CalcClearHistory" xml:space="preserve">
-    <value>清除历史</value>
+    <value>清除历史记录</value>
   </data>
   <data name="CalcClearMemory" xml:space="preserve">
-    <value>清除内存与历史</value>
+    <value>清除存储值和历史记录</value>
   </data>
   <data name="CalcClearOnNewInput" xml:space="preserve">
-    <value>新输入时清空显示（在「=」之后）</value>
+    <value>新输入时清空显示（在“=”之后）</value>
   </data>
   <data name="CalcCopy" xml:space="preserve">
     <value>复制</value>
@@ -299,7 +351,7 @@
     <value>显示颜色：</value>
   </data>
   <data name="CalcEntryCleared" xml:space="preserve">
-    <value>已清除输入</value>
+    <value>当前输入已清除</value>
   </data>
   <data name="CalcErrorDisplay" xml:space="preserve">
     <value>错误</value>
@@ -320,25 +372,10 @@
     <value>显示虚拟键盘</value>
   </data>
   <data name="CalcShowOperationNames" xml:space="preserve">
-    <value>显示运算名称（例如 加法）</value>
+    <value>显示运算名称（如“加法”）</value>
   </data>
   <data name="CalcShowTape" xml:space="preserve">
-    <value>显示计算纸带</value>
-  </data>
-  <data name="CatArchives" xml:space="preserve">
-    <value>压缩包</value>
-  </data>
-  <data name="CatCustomExtensions" xml:space="preserve">
-    <value>自定义扩展名...</value>
-  </data>
-  <data name="CatDocuments" xml:space="preserve">
-    <value>文档</value>
-  </data>
-  <data name="CatExecutables" xml:space="preserve">
-    <value>可执行文件</value>
-  </data>
-  <data name="CatImages" xml:space="preserve">
-    <value>图片</value>
+    <value>显示计算历史记录</value>
   </data>
   <data name="ColDateModified" xml:space="preserve">
     <value>修改日期</value>
@@ -350,7 +387,7 @@
     <value>米色</value>
   </data>
   <data name="ColorBismark" xml:space="preserve">
-    <value>Bismark</value>
+    <value>俾斯麦灰蓝</value>
   </data>
   <data name="ColorBlack" xml:space="preserve">
     <value>黑色</value>
@@ -391,23 +428,14 @@
   <data name="ConfirmDeleteTitle" xml:space="preserve">
     <value>确认删除</value>
   </data>
-  <data name="ConflictAutoRename" xml:space="preserve">
-    <value>自动重命名（例如 文件 (1).jpg）</value>
-  </data>
-  <data name="ConflictOverwrite" xml:space="preserve">
-    <value>覆盖（旧文件移入回收站）</value>
-  </data>
-  <data name="ConflictSkip" xml:space="preserve">
-    <value>跳过（保留在桌面）</value>
-  </data>
   <data name="CustomizeTitle" xml:space="preserve">
-    <value>自定义框</value>
+    <value>自定义面板</value>
   </data>
   <data name="DeleteFrameHeading" xml:space="preserve">
-    <value>删除框</value>
+    <value>删除面板</value>
   </data>
   <data name="DeleteFrameQuestion" xml:space="preserve">
-    <value>确定要删除这个框吗？</value>
+    <value>确定要删除这个面板吗？</value>
   </data>
   <data name="DeleteTabTitle" xml:space="preserve">
     <value>删除标签页</value>
@@ -449,7 +477,7 @@
     <value>恢复默认失败</value>
   </data>
   <data name="DlgDeleteProfile" xml:space="preserve">
-    <value>删除配置</value>
+    <value>删除工作区</value>
   </data>
   <data name="DlgDeleteTab" xml:space="preserve">
     <value>删除标签页</value>
@@ -530,7 +558,7 @@
     <value>整理桌面</value>
   </data>
   <data name="DlgUpdatePortalFrame" xml:space="preserve">
-    <value>更新门户框</value>
+    <value>更新文件夹面板</value>
   </data>
   <data name="DlgValidationError" xml:space="preserve">
     <value>输入无效</value>
@@ -545,10 +573,10 @@
     <value>编辑快捷方式</value>
   </data>
   <data name="FocusFrameTitle" xml:space="preserve">
-    <value>跳转到框</value>
+    <value>定位面板</value>
   </data>
   <data name="FocusSearchActive" xml:space="preserve">
-    <value>在活动的框中搜索：</value>
+    <value>搜索面板：</value>
   </data>
   <data name="FxAgitate" xml:space="preserve">
     <value>抖动</value>
@@ -602,7 +630,7 @@
     <value>左 (L)</value>
   </data>
   <data name="GaugeLeftVu" xml:space="preserve">
-    <value>左 VU</value>
+    <value>左声道 VU</value>
   </data>
   <data name="GaugeMasterVu" xml:space="preserve">
     <value>主 VU</value>
@@ -614,34 +642,34 @@
     <value>右 (R)</value>
   </data>
   <data name="GaugeRightVu" xml:space="preserve">
-    <value>右 VU</value>
+    <value>右声道 VU</value>
   </data>
   <data name="HkDirectProfile" xml:space="preserve">
-    <value>直接配置 [0-9]</value>
+    <value>直接切换工作区 [0-9]</value>
   </data>
   <data name="HkFocusFrame" xml:space="preserve">
-    <value>跳转到框</value>
+    <value>定位面板</value>
   </data>
   <data name="HkNextProfile" xml:space="preserve">
-    <value>下一个配置</value>
+    <value>下一个工作区</value>
   </data>
   <data name="HkPreviousProfile" xml:space="preserve">
-    <value>上一个配置</value>
+    <value>上一个工作区</value>
   </data>
   <data name="HkSpotSearch" xml:space="preserve">
     <value>快速搜索</value>
   </data>
   <data name="IconPickerHint" xml:space="preserve">
-    <value>从可用图标中选择一个，然后点击确定</value>
+    <value>从可用图标中选择一个，然后单击“确定”。</value>
   </data>
   <data name="IconPickerTitle" xml:space="preserve">
     <value>选择图标</value>
   </data>
   <data name="ImportTabNoFrames" xml:space="preserve">
-    <value>没有其他可导入的数据框。</value>
+    <value>没有其他可导入的面板。</value>
   </data>
   <data name="ImportTabPrompt" xml:space="preserve">
-    <value>选择要导入的框或标签页：</value>
+    <value>选择要导入的面板或标签页：</value>
   </data>
   <data name="ImportTabTitle" xml:space="preserve">
     <value>导入标签页</value>
@@ -653,7 +681,7 @@
     <value>米色</value>
   </data>
   <data name="ItemBismark" xml:space="preserve">
-    <value>Bismark</value>
+    <value>俾斯麦灰蓝</value>
   </data>
   <data name="ItemBlack" xml:space="preserve">
     <value>黑色</value>
@@ -668,7 +696,7 @@
     <value>默认</value>
   </data>
   <data name="ItemDetails" xml:space="preserve">
-    <value>列表</value>
+    <value>详细信息</value>
   </data>
   <data name="ItemElastic" xml:space="preserve">
     <value>弹性</value>
@@ -737,7 +765,7 @@
     <value>超新星</value>
   </data>
   <data name="ItemTeal" xml:space="preserve">
-    <value>青色</value>
+    <value>蓝绿色</value>
   </data>
   <data name="ItemTeleport" xml:space="preserve">
     <value>瞬移</value>
@@ -775,24 +803,6 @@
   <data name="KeyTilde" xml:space="preserve">
     <value>波浪号 (~)</value>
   </data>
-  <data name="LangAutomatic" xml:space="preserve">
-    <value>自动（跟随 Windows）</value>
-  </data>
-  <data name="LanguagePackBadName" xml:space="preserve">
-    <value>文件名必须是区域代码，例如 zh-Hans.resx 或 pt-BR.resx。</value>
-  </data>
-  <data name="LanguagePackFilter" xml:space="preserve">
-    <value>语言包 (*.resx)|*.resx</value>
-  </data>
-  <data name="LanguagePackImported" xml:space="preserve">
-    <value>语言包已安装：{0}。重启后可在列表中看到。</value>
-  </data>
-  <data name="LastRunAt" xml:space="preserve">
-    <value>上次成功运行：{0}</value>
-  </data>
-  <data name="LastRunNever" xml:space="preserve">
-    <value>上次成功运行：从未</value>
-  </data>
   <data name="LblActivationDelay" xml:space="preserve">
     <value>激活延迟：</value>
   </data>
@@ -812,7 +822,7 @@
     <value>自定义启动效果：</value>
   </data>
   <data name="LblDefaultPortalView" xml:space="preserve">
-    <value>默认门户视图：</value>
+    <value>默认文件夹面板视图：</value>
   </data>
   <data name="LblDisableTextShadow" xml:space="preserve">
     <value>关闭文字阴影</value>
@@ -830,7 +840,7 @@
     <value>已启用：{0}</value>
   </data>
   <data name="LblEnableProfileAutomation" xml:space="preserve">
-    <value>启用配置自动化</value>
+    <value>启用工作区自动切换</value>
   </data>
   <data name="LblFontFamily" xml:space="preserve">
     <value>字体：</value>
@@ -856,9 +866,6 @@
   <data name="LblIconSpacing" xml:space="preserve">
     <value>图标间距：</value>
   </data>
-  <data name="LblLanguage" xml:space="preserve">
-    <value>界面语言：</value>
-  </data>
   <data name="LblLockIcon" xml:space="preserve">
     <value>锁定图标</value>
   </data>
@@ -872,7 +879,7 @@
     <value>通知声音：</value>
   </data>
   <data name="LblPortalView" xml:space="preserve">
-    <value>门户视图：</value>
+    <value>文件夹面板视图：</value>
   </data>
   <data name="LblProcessName" xml:space="preserve">
     <value>进程名称（选择或输入）：</value>
@@ -884,7 +891,7 @@
     <value>目标路径：</value>
   </data>
   <data name="LblTargetProfile" xml:space="preserve">
-    <value>要激活的配置：</value>
+    <value>目标工作区：</value>
   </data>
   <data name="LblTextColor" xml:space="preserve">
     <value>文字颜色：</value>
@@ -893,7 +900,7 @@
     <value>标题颜色：</value>
   </data>
   <data name="LblTitleTextSize" xml:space="preserve">
-    <value>标题大小：</value>
+    <value>标题字号：</value>
   </data>
   <data name="LblTotalRules" xml:space="preserve">
     <value>规则总数：{0}</value>
@@ -905,7 +912,7 @@
     <value>关于…</value>
   </data>
   <data name="MenuAddPlugin" xml:space="preserve">
-    <value>添加小组件 | 插件</value>
+    <value>添加小组件/插件</value>
   </data>
   <data name="MenuAddSpacer" xml:space="preserve">
     <value>添加间隔</value>
@@ -947,13 +954,13 @@
     <value>删除项目</value>
   </data>
   <data name="MenuDeleteThisFrame" xml:space="preserve">
-    <value>删除此框</value>
+    <value>删除此面板</value>
   </data>
   <data name="MenuEdit" xml:space="preserve">
     <value>编辑…</value>
   </data>
   <data name="MenuEnableTabs" xml:space="preserve">
-    <value>在此框启用标签页</value>
+    <value>为此面板启用标签页</value>
   </data>
   <data name="MenuExit" xml:space="preserve">
     <value>退出</value>
@@ -962,7 +969,7 @@
     <value>将所有图标导出到桌面</value>
   </data>
   <data name="MenuExportThisFrame" xml:space="preserve">
-    <value>导出此框</value>
+    <value>导出此面板</value>
   </data>
   <data name="MenuFolderPath" xml:space="preserve">
     <value>文件夹路径</value>
@@ -971,31 +978,31 @@
     <value>完整路径</value>
   </data>
   <data name="MenuHideFrame" xml:space="preserve">
-    <value>隐藏此框</value>
+    <value>隐藏此面板</value>
   </data>
   <data name="MenuImportFrame" xml:space="preserve">
-    <value>导入框…</value>
+    <value>导入面板…</value>
   </data>
   <data name="MenuMove" xml:space="preserve">
     <value>移动…</value>
   </data>
   <data name="MenuNameAfterPath" xml:space="preserve">
-    <value>用目标路径命名此框</value>
+    <value>以目标路径命名此面板</value>
   </data>
   <data name="MenuNewFrame" xml:space="preserve">
-    <value>新建框</value>
+    <value>新建面板</value>
   </data>
   <data name="MenuNewNoteFrame" xml:space="preserve">
-    <value>新建便签框</value>
+    <value>新建便签面板</value>
   </data>
   <data name="MenuNewPortalFrame" xml:space="preserve">
-    <value>新建门户框</value>
+    <value>新建文件夹面板</value>
   </data>
   <data name="MenuNoPluginsAvailable" xml:space="preserve">
-    <value>（当前级别没有可用插件）</value>
+    <value>（此级别没有可用插件）</value>
   </data>
   <data name="MenuOpenFrameFolder" xml:space="preserve">
-    <value>打开框所在文件夹</value>
+    <value>打开面板所在文件夹</value>
   </data>
   <data name="MenuOpenTargetFolder" xml:space="preserve">
     <value>打开目标文件夹…</value>
@@ -1010,7 +1017,7 @@
     <value>粘贴项目</value>
   </data>
   <data name="MenuPeekBehind" xml:space="preserve">
-    <value>查看背后</value>
+    <value>临时查看桌面</value>
   </data>
   <data name="MenuPluginSettings" xml:space="preserve">
     <value>插件设置…</value>
@@ -1028,7 +1035,7 @@
     <value>重置排序</value>
   </data>
   <data name="MenuRestoreLastDeleted" xml:space="preserve">
-    <value>恢复上次删除的框</value>
+    <value>还原上次删除的面板</value>
   </data>
   <data name="MenuRunAsAdmin" xml:space="preserve">
     <value>以管理员身份运行</value>
@@ -1046,10 +1053,10 @@
     <value>圆点</value>
   </data>
   <data name="MenuViewAsDetails" xml:space="preserve">
-    <value>以列表显示</value>
+    <value>以详细信息显示</value>
   </data>
   <data name="MoveItemPrompt" xml:space="preserve">
-    <value>选择目标框或标签页：</value>
+    <value>选择目标面板或标签页：</value>
   </data>
   <data name="MoveItemTitle" xml:space="preserve">
     <value>移动项目到…</value>
@@ -1076,40 +1083,40 @@
     <value>无法删除最后一个标签页。</value>
   </data>
   <data name="MsgConfirmDeleteProfile" xml:space="preserve">
-    <value>确定要删除配置“{0}”吗？
+    <value>确定要删除工作区“{0}”吗？
 此操作无法撤销。</value>
   </data>
   <data name="MsgConfirmDisableCtrlAltHotkeys" xml:space="preserve">
-    <value>配置快捷键当前设为 Ctrl+Alt。
+    <value>工作区快捷键当前使用 Ctrl+Alt。
 
-在许多国际键盘上，Windows 把这个组合同时用作 'AltGr' 键。这会导致无法输入 @、€、[ 或 { 等字符。
+在许多国际键盘布局中，Windows 也会将此组合视为 AltGr 键，可能导致 @、€、[、{ 等字符无法正常输入。
 
-• 点击“是”将其禁用（解决输入问题）
-• 点击“否”保留它们（如果一切正常）</value>
+• 选择“是”以禁用这些快捷键（解决输入问题）
+• 选择“否”以保留这些快捷键（如果当前使用正常）</value>
   </data>
   <data name="MsgConfirmFactoryReset" xml:space="preserve">
-    <value>警告：将删除当前配置的所有框、快捷方式和设置！
+    <value>警告：这将删除当前工作区的所有面板、快捷方式和设置！
 
 确定要继续吗？</value>
   </data>
   <data name="MsgConfirmImportIntoTab" xml:space="preserve">
-    <value>把“{0}”的内容导入到新标签页吗？</value>
+    <value>要将“{0}”的内容导入到新标签页吗？</value>
   </data>
   <data name="MsgConfirmResetCustomizations" xml:space="preserve">
-    <value>要重置所有外观自定义吗？</value>
+    <value>要重置所有外观自定义设置吗？</value>
   </data>
   <data name="MsgConfirmRestoreSettings" xml:space="preserve">
-    <value>此备份还包含配置设置（options.json）。
+    <value>此备份还包含设置文件（options.json）。
 
 是否同时还原全局设置？</value>
   </data>
   <data name="MsgConfirmSetPortalHome" xml:space="preserve">
-    <value>把这个文件夹设为新的来源吗？
+    <value>要将此文件夹设为新的起始目录吗？
 
 {0}</value>
   </data>
   <data name="MsgConfirmSweepDesktop" xml:space="preserve">
-    <value>桌面上已有的文件将按你的规则移动到目标文件夹。
+    <value>桌面上已有的文件将按照你的规则移动到目标位置。
 
 继续吗？</value>
   </data>
@@ -1120,11 +1127,11 @@
     <value>无法复制路径。</value>
   </data>
   <data name="MsgCreateProfileFailed" xml:space="preserve">
-    <value>无法创建配置。名称无效或已存在。</value>
+    <value>无法创建工作区。名称无效或已存在。</value>
   </data>
   <data name="MsgCustomizationsReset" xml:space="preserve">
-    <value>所有外观自定义已重置。
-图标和框的位置保持不变。</value>
+    <value>所有外观自定义设置已重置。
+图标和面板的位置保持不变。</value>
   </data>
   <data name="MsgDeleteItemFailed" xml:space="preserve">
     <value>无法删除该项目。</value>
@@ -1146,42 +1153,42 @@
   </data>
   <data name="MsgFactoryResetDone" xml:space="preserve">
     <value>已恢复出厂设置。
-应用程序将重新启动。</value>
+程序将重新启动。</value>
   </data>
   <data name="MsgFileNotFoundInProfile" xml:space="preserve">
-    <value>在当前配置中找不到文件：
+    <value>在当前工作区中找不到文件：
 {0}</value>
   </data>
   <data name="MsgFormInitFailed" xml:space="preserve">
     <value>打开窗口时出错：{0}</value>
   </data>
   <data name="MsgFrameExportedTo" xml:space="preserve">
-    <value>框已导出到：
+    <value>面板已导出到：
 {0}</value>
   </data>
   <data name="MsgFrameImported" xml:space="preserve">
-    <value>框导入成功。</value>
+    <value>面板导入成功。</value>
   </data>
   <data name="MsgFramesMovedIntoBounds" xml:space="preserve">
-    <value>已检查所有框并移回屏幕可见范围内。</value>
+    <value>已检查并将所有面板移回屏幕可见区域内。</value>
   </data>
   <data name="MsgGenericError" xml:space="preserve">
     <value>错误：{0}</value>
   </data>
   <data name="MsgGlobalSettingsRestored" xml:space="preserve">
     <value>全局设置已还原。
-应用程序将重新启动以应用更改。</value>
+程序将重新启动以应用更改。</value>
   </data>
   <data name="MsgHotkeysSavedRestartNeeded" xml:space="preserve">
-    <value>全局快捷键已保存并应用到所有配置。
+    <value>全局快捷键已保存并应用到所有工作区。
 
-请重新启动 Desktop Frames 以启用。</value>
+请重启 Desktop Frames + 以启用这些快捷键。</value>
   </data>
   <data name="MsgImportFailed" xml:space="preserve">
     <value>导入失败：{0}</value>
   </data>
   <data name="MsgImportFrameFailed" xml:space="preserve">
-    <value>无法导入框：{0}</value>
+    <value>无法导入面板：{0}</value>
   </data>
   <data name="MsgInitFailed" xml:space="preserve">
     <value>初始化出错：{0}</value>
@@ -1199,7 +1206,7 @@
     <value>启动时出错：{0}</value>
   </data>
   <data name="MsgLoadFramePropertiesFailed" xml:space="preserve">
-    <value>加载框属性时出错：{0}</value>
+    <value>加载面板属性时出错：{0}</value>
   </data>
   <data name="MsgLogFileNotFound" xml:space="preserve">
     <value>找不到日志文件。</value>
@@ -1214,13 +1221,13 @@
     <value>显示名称和目标路径不能为空。</value>
   </data>
   <data name="MsgNoFrameToRestore" xml:space="preserve">
-    <value>没有可还原的框</value>
+    <value>没有可还原的面板。</value>
   </data>
   <data name="MsgNoItemToPaste" xml:space="preserve">
-    <value>没有可粘贴的项目</value>
+    <value>没有可粘贴的项目。</value>
   </data>
   <data name="MsgNoPortalDestination" xml:space="preserve">
-    <value>此门户框尚未设置目标文件夹。</value>
+    <value>此文件夹面板尚未设置目标文件夹。</value>
   </data>
   <data name="MsgOpenCustomizeFailed" xml:space="preserve">
     <value>打开自定义窗口时出错：{0}</value>
@@ -1235,31 +1242,31 @@
     <value>粘贴项目时出错：{0}</value>
   </data>
   <data name="MsgPortalInitFailed" xml:space="preserve">
-    <value>无法初始化门户框：{0}</value>
+    <value>无法初始化文件夹面板：{0}</value>
   </data>
   <data name="MsgProfileCreated" xml:space="preserve">
-    <value>配置“{0}”创建成功。</value>
+    <value>工作区“{0}”创建成功。</value>
   </data>
   <data name="MsgProfileNameInvalid" xml:space="preserve">
-    <value>名称无效，或配置已存在。</value>
+    <value>名称无效，或同名工作区已存在。</value>
   </data>
   <data name="MsgProfileSystemError" xml:space="preserve">
-    <value>配置系统错误：{0}</value>
+    <value>工作区系统错误：{0}</value>
   </data>
   <data name="MsgRecycleBinFailed" xml:space="preserve">
     <value>无法把该项目移入回收站。</value>
   </data>
   <data name="MsgReloadFramesFailed" xml:space="preserve">
-    <value>重新加载框时出错：{0}</value>
+    <value>重新加载面板时出错：{0}</value>
   </data>
   <data name="MsgReloadingFramesFailed" xml:space="preserve">
-    <value>重新加载框时出错：{0}</value>
+    <value>重新加载面板时出错：{0}</value>
   </data>
   <data name="MsgRenameItemFailed" xml:space="preserve">
     <value>无法重命名该项目：{0}</value>
   </data>
   <data name="MsgRenameProfileFailed" xml:space="preserve">
-    <value>重命名失败。名称可能已被占用或无效。</value>
+    <value>重命名失败。名称可能无效或已被其他工作区使用。</value>
   </data>
   <data name="MsgResetCustomizationsFailed" xml:space="preserve">
     <value>重置自定义设置时出错：{0}</value>
@@ -1271,9 +1278,9 @@
     <value>重置失败：{0}</value>
   </data>
   <data name="MsgRestartForLanguage" xml:space="preserve">
-    <value>语言已保存。
+    <value>语言设置已保存。
 
-每个窗口在创建时读取自己的文字，因此更改会在程序重启后生效。
+界面语言将在程序重启后生效。
 
 现在重启吗？</value>
   </data>
@@ -1287,7 +1294,7 @@
     <value>还原失败：{0}</value>
   </data>
   <data name="MsgRestoreFrameFailed" xml:space="preserve">
-    <value>还原框时出错：{0}</value>
+    <value>还原面板时出错：{0}</value>
   </data>
   <data name="MsgRulesSaved" xml:space="preserve">
     <value>规则已保存并生效。</value>
@@ -1321,7 +1328,7 @@
     <value>本地网卡</value>
   </data>
   <data name="NetNoInterfaces" xml:space="preserve">
-    <value>没有活动的网络接口。</value>
+    <value>未找到活动的网络接口。</value>
   </data>
   <data name="NetOffline" xml:space="preserve">
     <value>离线</value>
@@ -1330,10 +1337,10 @@
     <value>公网 WAN 地址</value>
   </data>
   <data name="NetSelectInterfaces" xml:space="preserve">
-    <value>选择要显示的接口：</value>
+    <value>选择要显示的网络接口：</value>
   </data>
   <data name="NetSettings" xml:space="preserve">
-    <value>网络监视设置</value>
+    <value>网络监控设置</value>
   </data>
   <data name="NetShowDisconnected" xml:space="preserve">
     <value>显示已断开的接口</value>
@@ -1351,28 +1358,25 @@
     <value>无法访问</value>
   </data>
   <data name="NoteAutoOrganize" xml:space="preserve">
-    <value>提示：自动整理会持续监视桌面上的新文件。当某个文件符合已启用规则的条件时，会被真正移动到指定的门户框或文件夹。可用于长期保持桌面整洁，并让下载文件自动归位。</value>
+    <value>提示：自动整理会持续监视桌面上的新文件。符合已启用规则的文件会被实际移动到指定的文件夹面板或目标文件夹，可用于长期保持桌面整洁，并让下载文件自动归位。</value>
   </data>
   <data name="NoteAutoRoll" xml:space="preserve">
-    <value>提示：自动收起需在每个框的右键菜单中单独启用。</value>
+    <value>提示：需在每个面板的右键菜单中逐一开启自动收起功能。</value>
   </data>
   <data name="NoteClearAll" xml:space="preserve">
     <value>清除全部文字</value>
   </data>
   <data name="NoteClickEdit" xml:space="preserve">
-    <value>点击编辑便签内容</value>
+    <value>单击以编辑便签内容</value>
   </data>
   <data name="NoteClickFinish" xml:space="preserve">
-    <value>点击结束编辑</value>
+    <value>单击以完成编辑</value>
   </data>
   <data name="NoteCopyAll" xml:space="preserve">
     <value>复制全部文字</value>
   </data>
   <data name="NoteHotkeysRestart" xml:space="preserve">
-    <value>提示：全局快捷键的更改需重启程序后生效。</value>
-  </data>
-  <data name="NoteLanguageRestart" xml:space="preserve">
-    <value>注意：语言在程序重启后生效。放入 Languages 文件夹的语言包会在下次启动时读取。</value>
+    <value>提示：全局快捷键更改将在程序重启后生效。</value>
   </data>
   <data name="NoteTextFormat" xml:space="preserve">
     <value>文字格式…</value>
@@ -1384,7 +1388,7 @@
     <value>Desktop Frames + - 通知</value>
   </data>
   <data name="OptAutoHideFrames" xml:space="preserve">
-    <value>自动隐藏框</value>
+    <value>自动隐藏面板</value>
   </data>
   <data name="OptAutomaticBackup" xml:space="preserve">
     <value>自动备份（每日）</value>
@@ -1393,10 +1397,10 @@
     <value>启用自动整理</value>
   </data>
   <data name="OptChameleon" xml:space="preserve">
-    <value>变色龙模式（取用壁纸颜色）</value>
+    <value>变色龙模式（自动匹配壁纸颜色）</value>
   </data>
   <data name="OptDimensionSnap" xml:space="preserve">
-    <value>同时吸附尺寸</value>
+    <value>尺寸吸附</value>
   </data>
   <data name="OptDisableScrollbars" xml:space="preserve">
     <value>隐藏滚动条</value>
@@ -1408,22 +1412,22 @@
     <value>启用声音</value>
   </data>
   <data name="OptExecutionToasts" xml:space="preserve">
-    <value>显示执行通知</value>
+    <value>显示运行通知</value>
   </data>
   <data name="OptFocusFrameHotkey" xml:space="preserve">
-    <value>跳转到框的快捷键</value>
+    <value>定位面板快捷键</value>
   </data>
   <data name="OptFrameTint" xml:space="preserve">
-    <value>将框的色调同时应用到图标和文字</value>
+    <value>将面板色调同时应用到图标和文字</value>
   </data>
   <data name="OptHideIconsRunning" xml:space="preserve">
-    <value>程序运行时隐藏 Windows 图标</value>
+    <value>运行期间隐藏 Windows 桌面图标</value>
   </data>
   <data name="OptHideIconsWhenHidden" xml:space="preserve">
-    <value>框隐藏时隐藏 Windows 图标</value>
+    <value>面板隐藏时一并隐藏 Windows 桌面图标</value>
   </data>
   <data name="OptIdleFadeOut" xml:space="preserve">
-    <value>空闲时淡出框</value>
+    <value>空闲时淡出面板</value>
   </data>
   <data name="OptionsHeading" xml:space="preserve">
     <value>选项</value>
@@ -1432,25 +1436,25 @@
     <value>Desktop Frames + - 选项</value>
   </data>
   <data name="OptNewFrameContextMenu" xml:space="preserve">
-    <value>在桌面右键菜单中显示「新建框」</value>
+    <value>在桌面右键菜单中显示“新建面板”</value>
   </data>
   <data name="OptNoteWatermark" xml:space="preserve">
-    <value>便签框水印（即将推出）</value>
+    <value>便签面板水印（即将推出）</value>
   </data>
   <data name="OptPortalWatermark" xml:space="preserve">
-    <value>门户框水印</value>
+    <value>文件夹面板水印</value>
   </data>
   <data name="OptProfileHotkeys" xml:space="preserve">
-    <value>切换配置的快捷键</value>
+    <value>工作区切换快捷键</value>
   </data>
   <data name="OptRecycleBin" xml:space="preserve">
-    <value>门户框的「删除项目」使用回收站</value>
+    <value>文件夹面板中的“删除项目”改为放入回收站</value>
   </data>
   <data name="OptSingleClick" xml:space="preserve">
     <value>单击即可打开</value>
   </data>
   <data name="OptSnapNearFrames" xml:space="preserve">
-    <value>吸附相邻的框</value>
+    <value>与相邻面板吸附</value>
   </data>
   <data name="OptSpotSearchHotkey" xml:space="preserve">
     <value>快速搜索快捷键</value>
@@ -1462,19 +1466,19 @@
     <value>在通知区域显示图标</value>
   </data>
   <data name="PerfDynamicColors" xml:space="preserve">
-    <value>按数值为柱条着色</value>
+    <value>根据数值自动调整条形颜色</value>
   </data>
   <data name="PerfRefreshRate" xml:space="preserve">
-    <value>刷新频率（毫秒）：</value>
+    <value>刷新间隔（毫秒）：</value>
   </data>
   <data name="PerfSensors" xml:space="preserve">
     <value>要显示的传感器：</value>
   </data>
   <data name="PerfSettings" xml:space="preserve">
-    <value>性能设置</value>
+    <value>性能监视器设置</value>
   </data>
   <data name="PerfStaticBarColor" xml:space="preserve">
-    <value>固定柱条颜色：</value>
+    <value>固定条形颜色：</value>
   </data>
   <data name="PerfThemeLayout" xml:space="preserve">
     <value>主题与布局</value>
@@ -1483,13 +1487,13 @@
     <value>视觉样式：</value>
   </data>
   <data name="PhotoBlurCrossfade" xml:space="preserve">
-    <value>模糊交叉淡化</value>
+    <value>模糊淡入淡出</value>
   </data>
   <data name="PhotoCropToFill" xml:space="preserve">
-    <value>裁剪填满</value>
+    <value>裁剪并填满</value>
   </data>
   <data name="PhotoCrossfade" xml:space="preserve">
-    <value>经典交叉淡化</value>
+    <value>经典淡入淡出</value>
   </data>
   <data name="PhotoFitInside" xml:space="preserve">
     <value>完整显示</value>
@@ -1498,7 +1502,7 @@
     <value>图片适配方式：</value>
   </data>
   <data name="PhotoLiveRescan" xml:space="preserve">
-    <value>持续重扫文件夹（检测新增或删除的图片）</value>
+    <value>实时监视文件夹（自动检测图片的增减）</value>
   </data>
   <data name="PhotoNoTransition" xml:space="preserve">
     <value>无（立即切换）</value>
@@ -1519,7 +1523,7 @@
     <value>过渡效果：</value>
   </data>
   <data name="PhotoVerticalWipe" xml:space="preserve">
-    <value>柔和垂直擦除</value>
+    <value>柔和垂直擦拭</value>
   </data>
   <data name="PluginCalculator" xml:space="preserve">
     <value>计算器</value>
@@ -1528,25 +1532,25 @@
     <value>IP 信息</value>
   </data>
   <data name="PluginPerformance" xml:space="preserve">
-    <value>性能仪表</value>
+    <value>性能监视器</value>
   </data>
   <data name="PluginPhotoFrame" xml:space="preserve">
     <value>相框</value>
   </data>
   <data name="PluginQueueSaturation" xml:space="preserve">
-    <value>队列饱和度</value>
+    <value>系统队列饱和度</value>
   </data>
   <data name="PluginTerminal" xml:space="preserve">
     <value>终端</value>
   </data>
   <data name="PluginVuMeter" xml:space="preserve">
-    <value>VU 表</value>
+    <value>VU 电平表</value>
   </data>
   <data name="ProfileActive" xml:space="preserve">
-    <value>活动</value>
+    <value>当前使用中</value>
   </data>
   <data name="ProfileManagerTitle" xml:space="preserve">
-    <value>配置管理</value>
+    <value>工作区管理</value>
   </data>
   <data name="QueueConfig" xml:space="preserve">
     <value>系统队列配置</value>
@@ -1561,7 +1565,7 @@
     <value>[正在初始化…]</value>
   </data>
   <data name="QueueRefreshRate" xml:space="preserve">
-    <value>刷新频率：</value>
+    <value>刷新间隔：</value>
   </data>
   <data name="QueueShowCores" xml:space="preserve">
     <value>显示检测到的逻辑核心数</value>
@@ -1570,7 +1574,7 @@
     <value>显示标题（系统队列饱和度）</value>
   </data>
   <data name="QueueShowValues" xml:space="preserve">
-    <value>显示数值（每核线程数与待处理 I/O）</value>
+    <value>显示数值（每个核心的线程数与待处理 I/O）</value>
   </data>
   <data name="QueueTitle" xml:space="preserve">
     <value>系统队列饱和度</value>
@@ -1579,25 +1583,25 @@
     <value>[WMI 错误]</value>
   </data>
   <data name="RandomNameAdjectives" xml:space="preserve">
-    <value>高,低,小,广,宽,细,平,劲,冷,暖,柔,硬,暗,淡,快,慢,深,长,短,弯,薄,亮,轻,锐,钝,响,静,冷峻,和,齐,粗,滑,勇,烈,朴,旧,干,湿,强,弱</value>
+    <value>高,低,小,大,远,近,长,短,深,浅,宽,窄,冷,暖,明,暗,清,静,青,赤,白,黑,金,银,古,新,荒,绿,幽,孤,晴,雾,风,雪,云,月,星,晨,暮,夜</value>
   </data>
   <data name="RandomNameFormat" xml:space="preserve">
     <value>{0}{1}</value>
   </data>
   <data name="RandomNamePlaces" xml:space="preserve">
-    <value>湾,丘,湖,澳,峰,礁,沙丘,谷,原,坳,岩,岸,坡,渡,岬,崖,沼,塘,壁,林,洼,隘,洞,脊,瀑,丛,溪,崖角,径,尖</value>
+    <value>湾,丘,湖,峰,礁,沙,谷,原,岩,岸,坡,渡,岬,崖,沼,塘,林,洼,隘,洞,脊,瀑,溪,径,岭,川,泉,岛,港,滩</value>
   </data>
   <data name="SearchPlaceholder" xml:space="preserve">
     <value>输入以搜索…</value>
   </data>
   <data name="SearchTitle" xml:space="preserve">
-    <value>Desktop Frames 搜索</value>
+    <value>Desktop Frames + 搜索</value>
   </data>
   <data name="SecAppearance" xml:space="preserve">
     <value>外观</value>
   </data>
   <data name="SecAutoHideFrames" xml:space="preserve">
-    <value>自动隐藏框</value>
+    <value>自动隐藏面板</value>
   </data>
   <data name="SecDesktopIconVisibility" xml:space="preserve">
     <value>桌面图标可见性</value>
@@ -1610,9 +1614,6 @@
   </data>
   <data name="SecIdleFadeOut" xml:space="preserve">
     <value>空闲淡出</value>
-  </data>
-  <data name="SecLanguage" xml:space="preserve">
-    <value>语言</value>
   </data>
   <data name="SecLog" xml:space="preserve">
     <value>日志</value>
@@ -1627,10 +1628,10 @@
     <value>维护</value>
   </data>
   <data name="SecProfileManagement" xml:space="preserve">
-    <value>配置管理</value>
+    <value>工作区管理</value>
   </data>
   <data name="SecProfileSwitching" xml:space="preserve">
-    <value>配置切换</value>
+    <value>工作区切换</value>
   </data>
   <data name="SecSelections" xml:space="preserve">
     <value>选项</value>
@@ -1645,13 +1646,13 @@
     <value>实用工具</value>
   </data>
   <data name="SldAutoHideTime" xml:space="preserve">
-    <value>隐藏前等待（秒）</value>
+    <value>自动隐藏延迟（秒）</value>
   </data>
   <data name="SldFadeTargetOpacity" xml:space="preserve">
-    <value>淡出不透明度（%）</value>
+    <value>淡出后的不透明度（%）</value>
   </data>
   <data name="SldFrameTint" xml:space="preserve">
-    <value>框色调</value>
+    <value>面板色调</value>
   </data>
   <data name="SldIdleTime" xml:space="preserve">
     <value>空闲时间（秒）</value>
@@ -1663,28 +1664,28 @@
     <value>默认声音</value>
   </data>
   <data name="SndDoubleDing" xml:space="preserve">
-    <value>双叮</value>
+    <value>叮叮</value>
   </data>
   <data name="SndGentleDing" xml:space="preserve">
-    <value>轻柔叮</value>
+    <value>轻柔提示音</value>
   </data>
   <data name="SndMessageDing" xml:space="preserve">
-    <value>消息叮</value>
+    <value>消息提示音</value>
   </data>
   <data name="SndSmoothTickle" xml:space="preserve">
     <value>轻触</value>
   </data>
   <data name="SndSoftDing" xml:space="preserve">
-    <value>柔和叮</value>
+    <value>柔和提示音</value>
   </data>
   <data name="TabAddNew" xml:space="preserve">
-    <value>添加标签页</value>
+    <value>新建标签页</value>
   </data>
   <data name="TabAddNewHint" xml:space="preserve">
-    <value>添加标签页（Ctrl+单击可导入）</value>
+    <value>新建标签页（Ctrl+单击可导入）</value>
   </data>
   <data name="TabFrame" xml:space="preserve">
-    <value>框</value>
+    <value>面板</value>
   </data>
   <data name="TabGeneral" xml:space="preserve">
     <value>常规</value>
@@ -1696,7 +1697,7 @@
     <value>图标</value>
   </data>
   <data name="TabLookDeeper" xml:space="preserve">
-    <value>深入</value>
+    <value>高级</value>
   </data>
   <data name="TabMoveLeft" xml:space="preserve">
     <value>左移</value>
@@ -1705,7 +1706,7 @@
     <value>右移</value>
   </data>
   <data name="TabProfiles" xml:space="preserve">
-    <value>配置</value>
+    <value>工作区</value>
   </data>
   <data name="TabRename" xml:space="preserve">
     <value>重命名标签页</value>
@@ -1721,9 +1722,6 @@
   </data>
   <data name="TabTools" xml:space="preserve">
     <value>工具</value>
-  </data>
-  <data name="TargetPortalFrame" xml:space="preserve">
-    <value>门户框：{0}</value>
   </data>
   <data name="TermClearHistory" xml:space="preserve">
     <value>清除命令历史</value>
@@ -1750,7 +1748,7 @@
     <value>启动目录：</value>
   </data>
   <data name="TermTargetShell" xml:space="preserve">
-    <value>命令解释器：</value>
+    <value>默认 Shell：</value>
   </data>
   <data name="TextAppearance" xml:space="preserve">
     <value>文字外观</value>
@@ -1762,96 +1760,171 @@
     <value>文字格式</value>
   </data>
   <data name="TooltipAutoReposition" xml:space="preserve">
-    <value>自动重新定位已启用（隐藏设置）：框已自行管理。</value>
+    <value>已启用自动重新定位（隐藏设置）：面板会自动管理位置。</value>
   </data>
   <data name="TooltipBlankSpacer" xml:space="preserve">
-    <value>空白间隔（按住 CTRL 可移动）</value>
+    <value>空白间隔（按住 Ctrl 拖动）</value>
   </data>
   <data name="TooltipChameleon" xml:space="preserve">
-    <value>框会自动变色，与桌面背景融为一体。</value>
+    <value>面板会自动变色，以匹配桌面背景。</value>
   </data>
   <data name="TooltipClearFilter" xml:space="preserve">
     <value>清除筛选并关闭</value>
   </data>
   <data name="TooltipFilterFiles" xml:space="preserve">
-    <value>筛选文件（例如「*.jpg」，或用「&gt;*.tmp」排除）</value>
+    <value>筛选文件（例如“*.jpg”；使用“&gt;*.tmp”可排除）</value>
   </data>
   <data name="TooltipGoUp" xml:space="preserve">
-    <value>上级文件夹</value>
+    <value>转到上级文件夹</value>
   </data>
   <data name="TooltipSetHome" xml:space="preserve">
-    <value>将当前视图设为此框的主目录</value>
+    <value>将当前文件夹设为此文件夹面板的起始目录</value>
   </data>
   <data name="TrayCreateNewProfile" xml:space="preserve">
-    <value>新建配置…</value>
+    <value>新建工作区…</value>
   </data>
   <data name="TrayExportDoneText" xml:space="preserve">
     <value>注册表值已导出到程序文件夹。</value>
   </data>
   <data name="TrayExportDoneTitle" xml:space="preserve">
-    <value>Desktop Frames Plus</value>
+    <value>Desktop Frames +</value>
   </data>
   <data name="TrayExportFailedText" xml:space="preserve">
     <value>导出注册表值失败，请查看日志。</value>
   </data>
   <data name="TrayExportFailedTitle" xml:space="preserve">
-    <value>Desktop Frames Plus - 错误</value>
+    <value>Desktop Frames + - 错误</value>
   </data>
   <data name="TrayFocusFrame" xml:space="preserve">
-    <value>转到框...（{0}）</value>
+    <value>定位面板…（{0}）</value>
   </data>
   <data name="TrayManageProfiles" xml:space="preserve">
-    <value>管理配置…</value>
+    <value>管理工作区…</value>
   </data>
   <data name="TrayProfiles" xml:space="preserve">
-    <value>配置</value>
+    <value>工作区</value>
   </data>
   <data name="TrayReloadAllFrames" xml:space="preserve">
-    <value>重新加载所有框</value>
+    <value>重新加载所有面板</value>
   </data>
   <data name="TrayReloadingFrames" xml:space="preserve">
-    <value>正在重新加载框…</value>
+    <value>正在重新加载面板…</value>
   </data>
   <data name="TrayShowHiddenFrames" xml:space="preserve">
-    <value>显示隐藏的框</value>
+    <value>显示隐藏的面板</value>
   </data>
   <data name="UpdateAvailable" xml:space="preserve">
     <value>有可用更新</value>
   </data>
   <data name="ViewDetails" xml:space="preserve">
-    <value>列表</value>
+    <value>详细信息</value>
   </data>
   <data name="ViewIcons" xml:space="preserve">
     <value>图标</value>
   </data>
   <data name="VuAttack" xml:space="preserve">
-    <value>响应速度（起振，毫秒）：</value>
+    <value>指针上升响应（毫秒）：</value>
   </data>
   <data name="VuAttackHint" xml:space="preserve">
-    <value>默认：25 | 越低跳动越快 | 范围：1 - 1000</value>
+    <value>默认：25 | 越小，指针上升越快 | 范围：1–1000</value>
   </data>
   <data name="VuBallistics" xml:space="preserve">
-    <value>响应与调校</value>
+    <value>动态响应</value>
   </data>
   <data name="VuDecay" xml:space="preserve">
-    <value>平滑度（衰减，毫秒）：</value>
+    <value>指针回落响应（毫秒）：</value>
   </data>
   <data name="VuDecayHint" xml:space="preserve">
-    <value>默认：200 | 越高回落越柔和 | 范围：10 - 3000</value>
+    <value>默认：200 | 越大，指针回落越平滑 | 范围：10–3000</value>
   </data>
   <data name="VuDisplayOptions" xml:space="preserve">
     <value>显示选项</value>
   </data>
   <data name="VuGainHint" xml:space="preserve">
-    <value>默认：1.2 | 越高越灵敏 | 范围：0.1 - 10.0</value>
+    <value>默认：1.2 | 越大越灵敏 | 范围：0.1 - 10.0</value>
   </data>
   <data name="VuLayoutMode" xml:space="preserve">
     <value>布局：</value>
   </data>
   <data name="VuSettings" xml:space="preserve">
-    <value>VU 表设置</value>
+    <value>VU 电平表设置</value>
   </data>
   <data name="VuSignalGain" xml:space="preserve">
     <value>信号增益（倍数）：</value>
+  </data>
+  <data name="SecLanguage" xml:space="preserve">
+    <value>语言</value>
+  </data>
+  <data name="LblLanguage" xml:space="preserve">
+    <value>界面语言：</value>
+  </data>
+  <data name="LangAutomatic" xml:space="preserve">
+    <value>自动（跟随 Windows）</value>
+  </data>
+  <data name="BtnImportLanguagePack" xml:space="preserve">
+    <value>导入语言包…</value>
+  </data>
+  <data name="BtnOpenLanguagesFolder" xml:space="preserve">
+    <value>打开语言文件夹</value>
+  </data>
+  <data name="LanguagePackFilter" xml:space="preserve">
+    <value>语言包 (*.resx)|*.resx</value>
+  </data>
+  <data name="LanguagePackImported" xml:space="preserve">
+    <value>语言包已安装：{0}。重启后即可在列表中选择。</value>
+  </data>
+  <data name="LanguagePackBadName" xml:space="preserve">
+    <value>文件名必须使用语言区域代码，例如 zh-Hans.resx 或 pt-BR.resx。</value>
+  </data>
+  <data name="NoteLanguageRestart" xml:space="preserve">
+    <value>提示：界面语言将在程序重启后生效。放入 Languages 文件夹的语言包会在下次启动时加载。</value>
+  </data>
+  <data name="CatImages" xml:space="preserve">
+    <value>图片</value>
+  </data>
+  <data name="CatDocuments" xml:space="preserve">
+    <value>文档</value>
+  </data>
+  <data name="CatExecutables" xml:space="preserve">
+    <value>可执行文件</value>
+  </data>
+  <data name="CatArchives" xml:space="preserve">
+    <value>压缩文件</value>
+  </data>
+  <data name="CatCustomExtensions" xml:space="preserve">
+    <value>自定义扩展名…</value>
+  </data>
+  <data name="ConflictAutoRename" xml:space="preserve">
+    <value>自动重命名（例如“文件 (1).jpg”）</value>
+  </data>
+  <data name="ConflictOverwrite" xml:space="preserve">
+    <value>覆盖（旧文件移入回收站）</value>
+  </data>
+  <data name="ConflictSkip" xml:space="preserve">
+    <value>跳过（保留在桌面）</value>
+  </data>
+  <data name="TargetPortalFrame" xml:space="preserve">
+    <value>文件夹面板：{0}</value>
+  </data>
+  <data name="LastRunNever" xml:space="preserve">
+    <value>上次成功运行：尚未运行</value>
+  </data>
+  <data name="LastRunAt" xml:space="preserve">
+    <value>上次成功运行：{0}</value>
+  </data>
+  <data name="TabInterface" xml:space="preserve">
+    <value>界面</value>
+  </data>
+  <data name="TabAppearance" xml:space="preserve">
+    <value>外观</value>
+  </data>
+  <data name="TabIdleBehaviors" xml:space="preserve">
+    <value>空闲行为</value>
+  </data>
+  <data name="BtnExportTemplate" xml:space="preserve">
+    <value>导出语言模板…</value>
+  </data>
+  <data name="MsgTemplateExported" xml:space="preserve">
+    <value>语言模板已成功导出！</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary

Improve and review the Simplified Chinese (`zh-Hans`) localization for Desktop Frames +.

### What changed

- Reworked the existing AI-seeded translation into more natural Simplified Chinese UI copy.
- Standardized product terminology:
  - `Frame` / default data frame → `面板`
  - `Portal Frame` → `文件夹面板`
  - `Note Frame` → `便签面板`
  - `Profile` → `工作区`
  - kept `相框` for photo frames and `边框` for borders where those meanings are literal.
- Improved technical/plugin wording, including clearer VU meter attack/decay descriptions.
- Improved several user-facing settings and prompts, for example the Portal Frame recycle-bin option is now `文件夹面板中的“删除项目”改为放入回收站`.
- Preserved the current ResX structure and completed the newer localization-template entries included in the submitted resource file.

### Validation

- XML parses successfully.
- 594 unique resource keys are present.
- Format placeholders such as `{0}` / `{1}` were checked for parity.
- This PR changes only `Code/Desktop Frames/Localization/Strings.zh-Hans.resx`.