### PR TITLE
Stop the search hotkey from eating AltGr characters

### DIFF
--- a/Code/Desktop Frames/GlobalHotkeyManager.cs
+++ b/Code/Desktop Frames/GlobalHotkeyManager.cs
@@ -263,13 +263,18 @@ namespace Desktop_Frames
                         int triggerKey = SettingsManager.SpotSearchKey;
                         if (vkCode == triggerKey)
                         {
-                            string mod = SettingsManager.SpotSearchModifier?.ToLower();
-                            bool isModPressed = false;
-
-                            if (mod == "control") isModPressed = (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
-                            else if (mod == "alt") isModPressed = (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
-                            else if (mod == "shift") isModPressed = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
-                            else if (mod == "none") isModPressed = true;
+                            // Checked the same strict way as every other hotkey below: the
+                            // modifiers held must be exactly the ones configured, no more.
+                            //
+                            // Testing only for Control let AltGr through, because Windows
+                            // reports AltGr as Control plus Alt. On an Italian keyboard the
+                            // at sign is AltGr and the key this hotkey defaults to, so typing
+                            // an email address opened the search window and swallowed the
+                            // character - the hook returns 1 and the keystroke never arrives.
+                            string mod = SettingsManager.SpotSearchModifier;
+                            bool isModPressed = string.Equals(mod, "none", StringComparison.OrdinalIgnoreCase)
+                                ? true
+                                : CheckModifiersStrict(mod);
 
                             if (isKeyDown && isModPressed)
                             {


### PR DESCRIPTION
Typing an at sign on an Italian keyboard opens the search window and the character never arrives.

  ò  ->  VK 192   no modifiers
  @  ->  VK 192   Ctrl+Alt

Windows reports AltGr as Control plus Alt, and @ sits on the key the search hotkey defaults to. The check tested only that Control was down, never that Alt was up, so Control+192 matched. The hook then returns 1 and the keystroke is dropped.
Every other hotkey in that file already uses CheckModifiersStrict, which requires the modifiers held to be exactly the ones configured. The search hotkey now does the same. One file, one condition.

The same collision hits French, German, Spanish and Polish layouts. Written with AI assistance, under my direction and tested here.