### PR TITLE
Translate the strings the localization pass left behind

### DIFF
--- a/Code/Desktop Frames/App.xaml.cs
+++ b/Code/Desktop Frames/App.xaml.cs
@@ -34,6 +34,9 @@ namespace Desktop_Frames
             }
             catch (Exception ex)
             {
+                // English on purpose, and it has to stay that way: this runs when the
+                // block above failed, and that block is what loads the settings and the
+                // language. Strings would have nothing to read.
                 MessageBox.Show($"Profile Initialization Error: {ex.Message}", "Startup Error", MessageBoxButton.OK, MessageBoxImage.Error);
                 Shutdown();
                 return;

--- a/Code/Desktop Frames/FrameManager.cs
+++ b/Code/Desktop Frames/FrameManager.cs
@@ -3595,7 +3595,7 @@ namespace Desktop_Frames
                 var dataFrame = new
                 {
                     Id = Guid.NewGuid().ToString(),
-                    Title = "New Frame - Drop your shortcuts here",
+                    Title = Localization.Strings.NewFrameDefaultTitle,
                     X = 20.0,
                     Y = 20.0,
                     Width = 360.0,

--- a/Code/Desktop Frames/Localization/Strings.cs
+++ b/Code/Desktop Frames/Localization/Strings.cs
@@ -220,6 +220,7 @@ namespace Desktop_Frames.Localization
         public static string BtnOpenBackupsFolder => Get("BtnOpenBackupsFolder");
         public static string BtnOpenLog => Get("BtnOpenLog");
         public static string BtnOrganizeNow => Get("BtnOrganizeNow");
+        public static string BtnReadMore => Get("BtnReadMore");
         public static string BtnReset => Get("BtnReset");
         public static string BtnResetStyles => Get("BtnResetStyles");
         public static string BtnRestore => Get("BtnRestore");
@@ -227,6 +228,7 @@ namespace Desktop_Frames.Localization
         public static string BtnSaveToAll => Get("BtnSaveToAll");
         public static string BtnScreenBoundFrames => Get("BtnScreenBoundFrames");
         public static string BtnSmartDesktopRules => Get("BtnSmartDesktopRules");
+        public static string BtnUpdateNow => Get("BtnUpdateNow");
         public static string ButtonNo => Get("ButtonNo");
         public static string ButtonOk => Get("ButtonOk");
         public static string ButtonYes => Get("ButtonYes");
@@ -350,6 +352,7 @@ namespace Desktop_Frames.Localization
         public static string DlgApplyError => Get("DlgApplyError");
         public static string DlgBackup => Get("DlgBackup");
         public static string DlgBrowseError => Get("DlgBrowseError");
+        public static string DlgClearNote => Get("DlgClearNote");
         public static string DlgConfirmImport => Get("DlgConfirmImport");
         public static string DlgCopyError => Get("DlgCopyError");
         public static string DlgCopyItem => Get("DlgCopyItem");
@@ -390,6 +393,7 @@ namespace Desktop_Frames.Localization
         public static string MsgBackupDone => Get("MsgBackupDone");
         public static string MsgBackupFailed => Get("MsgBackupFailed");
         public static string MsgCannotDeleteLastTab => Get("MsgCannotDeleteLastTab");
+        public static string MsgClearNoteConfirm => Get("MsgClearNoteConfirm");
         public static string MsgConfirmDeleteProfile => Get("MsgConfirmDeleteProfile");
         public static string MsgConfirmDisableCtrlAltHotkeys => Get("MsgConfirmDisableCtrlAltHotkeys");
         public static string MsgConfirmFactoryReset => Get("MsgConfirmFactoryReset");
@@ -753,6 +757,7 @@ namespace Desktop_Frames.Localization
         public static string VuSignalGain => Get("VuSignalGain");
 
         // ── Generated frame names ──────────────────────────────────────────
+        public static string NewFrameDefaultTitle => Get("NewFrameDefaultTitle");
         public static string RandomNameAdjectives => Get("RandomNameAdjectives");
         public static string RandomNamePlaces => Get("RandomNamePlaces");
     }

--- a/Code/Desktop Frames/Localization/Strings.de.resx
+++ b/Code/Desktop Frames/Localization/Strings.de.resx
@@ -241,6 +241,9 @@ Heute wird es von Nikos Georgousis gepflegt, der es erweitert und stabiler sowie
   <data name="BtnOrganizeNow" xml:space="preserve">
     <value>Jetzt aufräumen</value>
   </data>
+  <data name="BtnReadMore" xml:space="preserve">
+    <value>Mehr erfahren...</value>
+  </data>
   <data name="BtnReset" xml:space="preserve">
     <value>Zurücksetzen</value>
   </data>
@@ -261,6 +264,9 @@ Heute wird es von Nikos Georgousis gepflegt, der es erweitert und stabiler sowie
   </data>
   <data name="BtnSmartDesktopRules" xml:space="preserve">
     <value>Regeln für den intelligenten Desktop…</value>
+  </data>
+  <data name="BtnUpdateNow" xml:space="preserve">
+    <value>Jetzt aktualisieren</value>
   </data>
   <data name="ButtonNo" xml:space="preserve">
     <value>Nein</value>
@@ -432,6 +438,9 @@ Heute wird es von Nikos Georgousis gepflegt, der es erweitert und stabiler sowie
   </data>
   <data name="DlgBrowseError" xml:space="preserve">
     <value>Fehler beim Durchsuchen</value>
+  </data>
+  <data name="DlgClearNote" xml:space="preserve">
+    <value>Notiz löschen</value>
   </data>
   <data name="DlgConfirmImport" xml:space="preserve">
     <value>Import bestätigen</value>
@@ -1075,6 +1084,9 @@ Heute wird es von Nikos Georgousis gepflegt, der es erweitert und stabiler sowie
   <data name="MsgCannotDeleteLastTab" xml:space="preserve">
     <value>Die letzte verbleibende Registerkarte kann nicht gelöscht werden.</value>
   </data>
+  <data name="MsgClearNoteConfirm" xml:space="preserve">
+    <value>Wirklich den gesamten Text dieser Notiz löschen?</value>
+  </data>
   <data name="MsgConfirmDeleteProfile" xml:space="preserve">
     <value>Soll das Profil '{0}' wirklich gelöscht werden?
 Das lässt sich nicht rückgängig machen.</value>
@@ -1349,6 +1361,9 @@ Jetzt neu starten?</value>
   </data>
   <data name="NetUnreachable" xml:space="preserve">
     <value>Nicht erreichbar</value>
+  </data>
+  <data name="NewFrameDefaultTitle" xml:space="preserve">
+    <value>Neuer Rahmen - Verknüpfungen hier ablegen</value>
   </data>
   <data name="NoteAutoOrganize" xml:space="preserve">
     <value>Hinweis: Das automatische Aufräumen beobachtet den Desktop auf neue Dateien. Erfüllt eine Datei die Bedingungen einer aktiven Regel, wird sie tatsächlich in den angegebenen Portal-Rahmen oder Ordner verschoben. So bleibt der Desktop dauerhaft aufgeräumt und Downloads landen von selbst am richtigen Ort.</value>

--- a/Code/Desktop Frames/Localization/Strings.es.resx
+++ b/Code/Desktop Frames/Localization/Strings.es.resx
@@ -241,6 +241,9 @@ Hoy la mantiene Nikos Georgousis, que la ha ampliado y la ha hecho más estable 
   <data name="BtnOrganizeNow" xml:space="preserve">
     <value>Organizar ahora</value>
   </data>
+  <data name="BtnReadMore" xml:space="preserve">
+    <value>Leer más...</value>
+  </data>
   <data name="BtnReset" xml:space="preserve">
     <value>Restablecer</value>
   </data>
@@ -261,6 +264,9 @@ Hoy la mantiene Nikos Georgousis, que la ha ampliado y la ha hecho más estable 
   </data>
   <data name="BtnSmartDesktopRules" xml:space="preserve">
     <value>Reglas del escritorio inteligente…</value>
+  </data>
+  <data name="BtnUpdateNow" xml:space="preserve">
+    <value>Actualizar ahora</value>
   </data>
   <data name="ButtonNo" xml:space="preserve">
     <value>No</value>
@@ -432,6 +438,9 @@ Hoy la mantiene Nikos Georgousis, que la ha ampliado y la ha hecho más estable 
   </data>
   <data name="DlgBrowseError" xml:space="preserve">
     <value>Error al examinar</value>
+  </data>
+  <data name="DlgClearNote" xml:space="preserve">
+    <value>Borrar nota</value>
   </data>
   <data name="DlgConfirmImport" xml:space="preserve">
     <value>Confirmar importación</value>
@@ -1075,6 +1084,9 @@ Hoy la mantiene Nikos Georgousis, que la ha ampliado y la ha hecho más estable 
   <data name="MsgCannotDeleteLastTab" xml:space="preserve">
     <value>No puedes eliminar la única pestaña que queda.</value>
   </data>
+  <data name="MsgClearNoteConfirm" xml:space="preserve">
+    <value>¿Seguro que quieres borrar todo el texto de esta nota?</value>
+  </data>
   <data name="MsgConfirmDeleteProfile" xml:space="preserve">
     <value>¿Seguro que quieres eliminar el perfil '{0}'?
 Esta acción no se puede deshacer.</value>
@@ -1349,6 +1361,9 @@ Cada ventana lee sus textos mientras se construye, así que el cambio se ve al r
   </data>
   <data name="NetUnreachable" xml:space="preserve">
     <value>Inalcanzable</value>
+  </data>
+  <data name="NewFrameDefaultTitle" xml:space="preserve">
+    <value>Nuevo marco - Suelta aquí tus accesos directos</value>
   </data>
   <data name="NoteAutoOrganize" xml:space="preserve">
     <value>Nota: la organización automática vigila el escritorio en busca de archivos nuevos. Cuando un archivo cumple las condiciones de una regla activa, se mueve de verdad al marco Portal o a la carpeta indicada. Sirve para mantener el escritorio limpio y encaminar las descargas solas.</value>

--- a/Code/Desktop Frames/Localization/Strings.fr.resx
+++ b/Code/Desktop Frames/Localization/Strings.fr.resx
@@ -241,6 +241,9 @@ Il est aujourd'hui maintenu par Nikos Georgousis, qui l'a enrichi et rendu plus 
   <data name="BtnOrganizeNow" xml:space="preserve">
     <value>Organiser maintenant</value>
   </data>
+  <data name="BtnReadMore" xml:space="preserve">
+    <value>En savoir plus...</value>
+  </data>
   <data name="BtnReset" xml:space="preserve">
     <value>Réinitialiser</value>
   </data>
@@ -261,6 +264,9 @@ Il est aujourd'hui maintenu par Nikos Georgousis, qui l'a enrichi et rendu plus 
   </data>
   <data name="BtnSmartDesktopRules" xml:space="preserve">
     <value>Règles du bureau intelligent…</value>
+  </data>
+  <data name="BtnUpdateNow" xml:space="preserve">
+    <value>Mettre à jour</value>
   </data>
   <data name="ButtonNo" xml:space="preserve">
     <value>Non</value>
@@ -432,6 +438,9 @@ Il est aujourd'hui maintenu par Nikos Georgousis, qui l'a enrichi et rendu plus 
   </data>
   <data name="DlgBrowseError" xml:space="preserve">
     <value>Erreur de parcours</value>
+  </data>
+  <data name="DlgClearNote" xml:space="preserve">
+    <value>Effacer la note</value>
   </data>
   <data name="DlgConfirmImport" xml:space="preserve">
     <value>Confirmer l'importation</value>
@@ -1075,6 +1084,9 @@ Il est aujourd'hui maintenu par Nikos Georgousis, qui l'a enrichi et rendu plus 
   <data name="MsgCannotDeleteLastTab" xml:space="preserve">
     <value>Impossible de supprimer le dernier onglet.</value>
   </data>
+  <data name="MsgClearNoteConfirm" xml:space="preserve">
+    <value>Voulez-vous vraiment effacer tout le texte de cette note ?</value>
+  </data>
   <data name="MsgConfirmDeleteProfile" xml:space="preserve">
     <value>Voulez-vous vraiment supprimer le profil '{0}' ?
 Cette action est irréversible.</value>
@@ -1349,6 +1361,9 @@ Redémarrer maintenant ?</value>
   </data>
   <data name="NetUnreachable" xml:space="preserve">
     <value>Injoignable</value>
+  </data>
+  <data name="NewFrameDefaultTitle" xml:space="preserve">
+    <value>Nouveau cadre - Déposez vos raccourcis ici</value>
   </data>
   <data name="NoteAutoOrganize" xml:space="preserve">
     <value>Remarque : l'organisation automatique surveille le bureau à la recherche de nouveaux fichiers. Quand un fichier remplit les conditions d'une règle active, il est réellement déplacé vers le cadre Portail ou le dossier indiqué. De quoi garder le bureau propre et router les téléchargements tout seuls.</value>

--- a/Code/Desktop Frames/Localization/Strings.it.resx
+++ b/Code/Desktop Frames/Localization/Strings.it.resx
@@ -234,6 +234,9 @@ Oggi lo cura Nikos Georgousis, che lo ha ampliato e reso più stabile e piacevol
   <data name="BtnOrganizeNow" xml:space="preserve">
     <value>Organizza adesso</value>
   </data>
+  <data name="BtnReadMore" xml:space="preserve">
+    <value>Leggi di più...</value>
+  </data>
   <data name="BtnReset" xml:space="preserve">
     <value>Reimposta</value>
   </data>
@@ -254,6 +257,9 @@ Oggi lo cura Nikos Georgousis, che lo ha ampliato e reso più stabile e piacevol
   </data>
   <data name="BtnSmartDesktopRules" xml:space="preserve">
     <value>Regole del desktop intelligente...</value>
+  </data>
+  <data name="BtnUpdateNow" xml:space="preserve">
+    <value>Aggiorna ora</value>
   </data>
   <data name="ButtonNo" xml:space="preserve">
     <value>No</value>
@@ -401,6 +407,9 @@ Oggi lo cura Nikos Georgousis, che lo ha ampliato e reso più stabile e piacevol
   </data>
   <data name="DlgBrowseError" xml:space="preserve">
     <value>Errore di sfoglia</value>
+  </data>
+  <data name="DlgClearNote" xml:space="preserve">
+    <value>Cancella nota</value>
   </data>
   <data name="DlgConfirmImport" xml:space="preserve">
     <value>Conferma importazione</value>
@@ -1023,6 +1032,9 @@ Oggi lo cura Nikos Georgousis, che lo ha ampliato e reso più stabile e piacevol
   <data name="MsgCannotDeleteLastTab" xml:space="preserve">
     <value>Non puoi eliminare l'ultima scheda rimasta.</value>
   </data>
+  <data name="MsgClearNoteConfirm" xml:space="preserve">
+    <value>Vuoi davvero cancellare tutto il testo di questa nota?</value>
+  </data>
   <data name="MsgConfirmDeleteProfile" xml:space="preserve">
     <value>Vuoi davvero eliminare il profilo '{0}'?
 L'operazione non si può annullare.</value>
@@ -1297,6 +1309,9 @@ Vuoi riavviare adesso?</value>
   </data>
   <data name="NetUnreachable" xml:space="preserve">
     <value>Irraggiungibile</value>
+  </data>
+  <data name="NewFrameDefaultTitle" xml:space="preserve">
+    <value>Nuova frame - Trascina qui i tuoi collegamenti</value>
   </data>
   <data name="NoteAutoOrganize" xml:space="preserve">
     <value>Nota: l'organizzazione automatica sorveglia il desktop in cerca di file nuovi. Quando un file soddisfa le condizioni di una regola attiva, viene spostato davvero nella frame Portal o nella cartella indicata. Serve a tenere il desktop sempre pulito e a smistare i download da soli.</value>

--- a/Code/Desktop Frames/Localization/Strings.pl.resx
+++ b/Code/Desktop Frames/Localization/Strings.pl.resx
@@ -241,6 +241,9 @@ Dziś opiekuje się nim Nikos Georgousis, który je rozbudował oraz uczynił st
   <data name="BtnOrganizeNow" xml:space="preserve">
     <value>Uporządkuj teraz</value>
   </data>
+  <data name="BtnReadMore" xml:space="preserve">
+    <value>Czytaj więcej...</value>
+  </data>
   <data name="BtnReset" xml:space="preserve">
     <value>Resetuj</value>
   </data>
@@ -261,6 +264,9 @@ Dziś opiekuje się nim Nikos Georgousis, który je rozbudował oraz uczynił st
   </data>
   <data name="BtnSmartDesktopRules" xml:space="preserve">
     <value>Reguły inteligentnego pulpitu…</value>
+  </data>
+  <data name="BtnUpdateNow" xml:space="preserve">
+    <value>Aktualizuj teraz</value>
   </data>
   <data name="ButtonNo" xml:space="preserve">
     <value>Nie</value>
@@ -432,6 +438,9 @@ Dziś opiekuje się nim Nikos Georgousis, który je rozbudował oraz uczynił st
   </data>
   <data name="DlgBrowseError" xml:space="preserve">
     <value>Błąd przeglądania</value>
+  </data>
+  <data name="DlgClearNote" xml:space="preserve">
+    <value>Wyczyść notatkę</value>
   </data>
   <data name="DlgConfirmImport" xml:space="preserve">
     <value>Potwierdź import</value>
@@ -1075,6 +1084,9 @@ Dziś opiekuje się nim Nikos Georgousis, który je rozbudował oraz uczynił st
   <data name="MsgCannotDeleteLastTab" xml:space="preserve">
     <value>Nie można usunąć ostatniej karty.</value>
   </data>
+  <data name="MsgClearNoteConfirm" xml:space="preserve">
+    <value>Czy na pewno wyczyścić cały tekst tej notatki?</value>
+  </data>
   <data name="MsgConfirmDeleteProfile" xml:space="preserve">
     <value>Czy na pewno usunąć profil '{0}'?
 Tej operacji nie można cofnąć.</value>
@@ -1349,6 +1361,9 @@ Uruchomić ponownie teraz?</value>
   </data>
   <data name="NetUnreachable" xml:space="preserve">
     <value>Nieosiągalny</value>
+  </data>
+  <data name="NewFrameDefaultTitle" xml:space="preserve">
+    <value>Nowa ramka - Upuść tutaj swoje skróty</value>
   </data>
   <data name="NoteAutoOrganize" xml:space="preserve">
     <value>Uwaga: automatyczne porządkowanie obserwuje pulpit w poszukiwaniu nowych plików. Gdy plik spełnia warunki włączonej reguły, zostaje naprawdę przeniesiony do wskazanej ramki Portal lub folderu. Dzięki temu pulpit pozostaje czysty, a pobrane pliki same trafiają na swoje miejsce.</value>

--- a/Code/Desktop Frames/Localization/Strings.pt.resx
+++ b/Code/Desktop Frames/Localization/Strings.pt.resx
@@ -241,6 +241,9 @@ Hoje é mantido por Nikos Georgousis, que o alargou e o tornou mais estável e a
   <data name="BtnOrganizeNow" xml:space="preserve">
     <value>Organizar agora</value>
   </data>
+  <data name="BtnReadMore" xml:space="preserve">
+    <value>Saber mais...</value>
+  </data>
   <data name="BtnReset" xml:space="preserve">
     <value>Repor</value>
   </data>
@@ -261,6 +264,9 @@ Hoje é mantido por Nikos Georgousis, que o alargou e o tornou mais estável e a
   </data>
   <data name="BtnSmartDesktopRules" xml:space="preserve">
     <value>Regras do ambiente de trabalho inteligente…</value>
+  </data>
+  <data name="BtnUpdateNow" xml:space="preserve">
+    <value>Atualizar agora</value>
   </data>
   <data name="ButtonNo" xml:space="preserve">
     <value>Não</value>
@@ -432,6 +438,9 @@ Hoje é mantido por Nikos Georgousis, que o alargou e o tornou mais estável e a
   </data>
   <data name="DlgBrowseError" xml:space="preserve">
     <value>Erro ao procurar</value>
+  </data>
+  <data name="DlgClearNote" xml:space="preserve">
+    <value>Apagar nota</value>
   </data>
   <data name="DlgConfirmImport" xml:space="preserve">
     <value>Confirmar importação</value>
@@ -1075,6 +1084,9 @@ Hoje é mantido por Nikos Georgousis, que o alargou e o tornou mais estável e a
   <data name="MsgCannotDeleteLastTab" xml:space="preserve">
     <value>Não é possível eliminar o último separador.</value>
   </data>
+  <data name="MsgClearNoteConfirm" xml:space="preserve">
+    <value>Quer mesmo apagar todo o texto desta nota?</value>
+  </data>
   <data name="MsgConfirmDeleteProfile" xml:space="preserve">
     <value>Tem a certeza de que quer eliminar o perfil '{0}'?
 Esta ação não pode ser anulada.</value>
@@ -1349,6 +1361,9 @@ Reiniciar agora?</value>
   </data>
   <data name="NetUnreachable" xml:space="preserve">
     <value>Inacessível</value>
+  </data>
+  <data name="NewFrameDefaultTitle" xml:space="preserve">
+    <value>Nova moldura - Largue aqui os seus atalhos</value>
   </data>
   <data name="NoteAutoOrganize" xml:space="preserve">
     <value>Nota: a organização automática vigia o ambiente de trabalho à procura de ficheiros novos. Quando um ficheiro cumpre as condições de uma regra ativa, é mesmo movido para a moldura Portal ou pasta indicada. Serve para manter o ambiente de trabalho limpo e encaminhar as transferências sozinho.</value>

--- a/Code/Desktop Frames/Localization/Strings.resx
+++ b/Code/Desktop Frames/Localization/Strings.resx
@@ -234,6 +234,9 @@ Desktop Frames + is maintained by Nikos Georgousis, has been enhanced and optimi
   <data name="BtnOrganizeNow" xml:space="preserve">
     <value>Organize Now (Run)</value>
   </data>
+  <data name="BtnReadMore" xml:space="preserve">
+    <value>Read More...</value>
+  </data>
   <data name="BtnReset" xml:space="preserve">
     <value>Reset</value>
   </data>
@@ -254,6 +257,9 @@ Desktop Frames + is maintained by Nikos Georgousis, has been enhanced and optimi
   </data>
   <data name="BtnSmartDesktopRules" xml:space="preserve">
     <value>Smart Desktop Rules...</value>
+  </data>
+  <data name="BtnUpdateNow" xml:space="preserve">
+    <value>Update Now</value>
   </data>
   <data name="ButtonNo" xml:space="preserve">
     <value>No</value>
@@ -401,6 +407,9 @@ Desktop Frames + is maintained by Nikos Georgousis, has been enhanced and optimi
   </data>
   <data name="DlgBrowseError" xml:space="preserve">
     <value>Browse Error</value>
+  </data>
+  <data name="DlgClearNote" xml:space="preserve">
+    <value>Clear Note</value>
   </data>
   <data name="DlgConfirmImport" xml:space="preserve">
     <value>Confirm Import</value>
@@ -1023,6 +1032,9 @@ Desktop Frames + is maintained by Nikos Georgousis, has been enhanced and optimi
   <data name="MsgCannotDeleteLastTab" xml:space="preserve">
     <value>Cannot delete the last remaining tab.</value>
   </data>
+  <data name="MsgClearNoteConfirm" xml:space="preserve">
+    <value>Are you sure you want to clear all text from this note?</value>
+  </data>
   <data name="MsgConfirmDeleteProfile" xml:space="preserve">
     <value>Are you sure you want to delete profile '{0}'?
 This cannot be undone.</value>
@@ -1297,6 +1309,9 @@ Restart now?</value>
   </data>
   <data name="NetUnreachable" xml:space="preserve">
     <value>Unreachable</value>
+  </data>
+  <data name="NewFrameDefaultTitle" xml:space="preserve">
+    <value>New Frame - Drop your shortcuts here</value>
   </data>
   <data name="NoteAutoOrganize" xml:space="preserve">
     <value>Note: Auto-Organize continuously monitors your Desktop for new files. When a file matches an enabled rule's conditions, it is automatically and physically moved to your target Portal Frame or Folder. Use this to keep your Desktop permanently clean and automatically route downloads to their proper locations.</value>

--- a/Code/Desktop Frames/Localization/Strings.ru.resx
+++ b/Code/Desktop Frames/Localization/Strings.ru.resx
@@ -241,6 +241,9 @@
   <data name="BtnOrganizeNow" xml:space="preserve">
     <value>Разобрать сейчас</value>
   </data>
+  <data name="BtnReadMore" xml:space="preserve">
+    <value>Подробнее...</value>
+  </data>
   <data name="BtnReset" xml:space="preserve">
     <value>Сбросить</value>
   </data>
@@ -261,6 +264,9 @@
   </data>
   <data name="BtnSmartDesktopRules" xml:space="preserve">
     <value>Правила умного рабочего стола…</value>
+  </data>
+  <data name="BtnUpdateNow" xml:space="preserve">
+    <value>Обновить</value>
   </data>
   <data name="ButtonNo" xml:space="preserve">
     <value>Нет</value>
@@ -432,6 +438,9 @@
   </data>
   <data name="DlgBrowseError" xml:space="preserve">
     <value>Ошибка обзора</value>
+  </data>
+  <data name="DlgClearNote" xml:space="preserve">
+    <value>Очистить заметку</value>
   </data>
   <data name="DlgConfirmImport" xml:space="preserve">
     <value>Подтверждение импорта</value>
@@ -1075,6 +1084,9 @@
   <data name="MsgCannotDeleteLastTab" xml:space="preserve">
     <value>Нельзя удалить последнюю оставшуюся вкладку.</value>
   </data>
+  <data name="MsgClearNoteConfirm" xml:space="preserve">
+    <value>Действительно очистить весь текст этой заметки?</value>
+  </data>
   <data name="MsgConfirmDeleteProfile" xml:space="preserve">
     <value>Удалить профиль «{0}»?
 Это действие нельзя отменить.</value>
@@ -1349,6 +1361,9 @@
   </data>
   <data name="NetUnreachable" xml:space="preserve">
     <value>Недоступно</value>
+  </data>
+  <data name="NewFrameDefaultTitle" xml:space="preserve">
+    <value>Новая рамка - перетащите сюда ярлыки</value>
   </data>
   <data name="NoteAutoOrganize" xml:space="preserve">
     <value>Примечание: автоматическая разборка следит за появлением новых файлов на рабочем столе. Когда файл подходит под условия включённого правила, он действительно переносится в указанную рамку-портал или папку. Так рабочий стол остаётся чистым, а загрузки сами попадают куда нужно.</value>

--- a/Code/Desktop Frames/Localization/Strings.zh-Hans.resx
+++ b/Code/Desktop Frames/Localization/Strings.zh-Hans.resx
@@ -293,6 +293,9 @@
   <data name="BtnOrganizeNow" xml:space="preserve">
     <value>立即整理</value>
   </data>
+  <data name="BtnReadMore" xml:space="preserve">
+    <value>了解更多...</value>
+  </data>
   <data name="BtnReset" xml:space="preserve">
     <value>重置</value>
   </data>
@@ -313,6 +316,9 @@
   </data>
   <data name="BtnSmartDesktopRules" xml:space="preserve">
     <value>智能桌面规则…</value>
+  </data>
+  <data name="BtnUpdateNow" xml:space="preserve">
+    <value>立即更新</value>
   </data>
   <data name="ButtonNo" xml:space="preserve">
     <value>否</value>
@@ -460,6 +466,9 @@
   </data>
   <data name="DlgBrowseError" xml:space="preserve">
     <value>浏览失败</value>
+  </data>
+  <data name="DlgClearNote" xml:space="preserve">
+    <value>清除便签</value>
   </data>
   <data name="DlgConfirmImport" xml:space="preserve">
     <value>确认导入</value>
@@ -1082,6 +1091,9 @@
   <data name="MsgCannotDeleteLastTab" xml:space="preserve">
     <value>无法删除最后一个标签页。</value>
   </data>
+  <data name="MsgClearNoteConfirm" xml:space="preserve">
+    <value>确定要清除这个便签的全部文字吗？</value>
+  </data>
   <data name="MsgConfirmDeleteProfile" xml:space="preserve">
     <value>确定要删除工作区“{0}”吗？
 此操作无法撤销。</value>
@@ -1356,6 +1368,9 @@
   </data>
   <data name="NetUnreachable" xml:space="preserve">
     <value>无法访问</value>
+  </data>
+  <data name="NewFrameDefaultTitle" xml:space="preserve">
+    <value>新建面板 - 将快捷方式拖到这里</value>
   </data>
   <data name="NoteAutoOrganize" xml:space="preserve">
     <value>提示：自动整理会持续监视桌面上的新文件。符合已启用规则的文件会被实际移动到指定的文件夹面板或目标文件夹，可用于长期保持桌面整洁，并让下载文件自动归位。</value>

--- a/Code/Desktop Frames/NoteFrameManager.cs
+++ b/Code/Desktop Frames/NoteFrameManager.cs
@@ -749,8 +749,8 @@ namespace Desktop_Frames
         {
             try
             {
-                if (MessageBox.Show("Are you sure you want to clear all text from this note?",
-                    "Clear Note", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                if (MessageBox.Show(Strings.MsgClearNoteConfirm,
+                    Strings.DlgClearNote, MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
                 {
                     noteTextBox.Text = "";
                     SaveNoteContent(frame, "");

--- a/Code/Desktop Frames/NotificationFormManager.cs
+++ b/Code/Desktop Frames/NotificationFormManager.cs
@@ -145,7 +145,7 @@ namespace Desktop_Frames
             {
                 Button btnLink = new Button
                 {
-                    Content = _msg.Type == "Info" ? "Read More..." : "Update Now",
+                    Content = _msg.Type == "Info" ? Strings.BtnReadMore : Strings.BtnUpdateNow,
                     HorizontalAlignment = HorizontalAlignment.Right,
                     Padding = new Thickness(10, 5, 10, 5),
                     Margin = new Thickness(0, 0, 0, 10),

--- a/Code/Desktop Frames/Plugins/CalculatorPlugin.cs
+++ b/Code/Desktop Frames/Plugins/CalculatorPlugin.cs
@@ -985,7 +985,7 @@ namespace Desktop_Frames.Plugins
             contentPanel.Children.Add(fadeSp);
 
             Button btnClearMem = new Button { Content = Strings.CalcClearMemory, Padding = new Thickness(5), Margin = new Thickness(0, 10, 0, 0) };
-            btnClearMem.Click += (s, e) => { _memoryValue = 0; _historyTape.Clear(); SaveState(); UpdateDisplay(); MessageBox.Show("Cleared.", "Calculator", MessageBoxButton.OK, MessageBoxImage.Information); };
+            btnClearMem.Click += (s, e) => { _memoryValue = 0; _historyTape.Clear(); SaveState(); UpdateDisplay(); MessageBox.Show(Strings.CalcCleared, Strings.PluginCalculator, MessageBoxButton.OK, MessageBoxImage.Information); };
             contentPanel.Children.Add(btnClearMem);
 
             contentBorder.Child = contentPanel;


### PR DESCRIPTION
Five pieces of user-facing text were still English, in files already converted around them. The announcement window shows it best: its title and its "don't show again" checkbox go through `Strings`, and the button between them did not.

- the announcement button — "Read More..." / "Update Now"
- the confirmation before clearing a note, and its dialog title
- the calculator's message after clearing memory and history
- the title of the frame created on first run

Four new keys, added to all nine languages. The calculator needed none: `CalcCleared` and `PluginCalculator` already existed and say exactly this.

Wording follows what each language already uses nearby — the confirmation matches the short form of `DeleteFrameQuestion` rather than the longer English phrasing, and the frame title uses each language's existing word for a frame.

Left in English on purpose: key names ("Ctrl", "Shift"), the product name, the generated file name in `BackupManager`, and the start-up failure messages in `App.xaml.cs` — those run inside the block that loads the settings and the language, so `Strings` has nothing to read yet. A comment now says so.
